### PR TITLE
FIX: 윈도우에서 발생하는 eslint/prettier 오류 해결

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,5 +54,12 @@ module.exports = {
         alphabetize: { order: 'desc', caseInsensitive: true },
       },
     ],
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
+    'no-console': 'off',
   },
 };


### PR DESCRIPTION
`.eslintrc.js` 파일을 수정하여 오류를 해결했습니다. 